### PR TITLE
Add scheduler runner

### DIFF
--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -73,11 +73,8 @@ with left_column:
     no_cmb = st.checkbox("No CMB", value=False)
     az_speed = st.number_input("Azimuth Speed (deg/s)", value=0.5)
     az_accel = st.number_input("Azimuth Acceleration (deg/s²)", value=0.25)
-    az_offset = st.number_input("Azimuth Offset (deg)", value=0.0)
-    el_offset = st.number_input("Elevation Offset (deg)", value=0.0)
-    xi_offset = st.number_input("Xi Offset (deg)", value=0.0)
-    eta_offset = st.number_input("Eta Offset (deg)", value=0.0)
     iv_cadence = st.number_input("IV Cadence (seconds)", value=14400)
+    relock_cadence = st.number_input("Relock Cadence (seconds)", value=86400)
     bias_step_cadence = st.number_input("Bias Step Cadence (seconds)", value=1800)
     min_hwp_el = st.number_input("Min HWP Elevation (deg)", value=48.0)
     max_cmb_scan_duration = st.number_input("Max CMB Scan Duration (seconds)", value=3600)
@@ -89,7 +86,6 @@ with right_column:
     hwp_override = st.checkbox("HWP Override", value=False)
     az_motion_override = st.checkbox("Az Motion Override", value=False)
     home_at_end = st.checkbox("Home at End", value=False)
-    relock_cadence = st.number_input("Relock Cadence (seconds)", value=86400)
     disable_hwp = st.checkbox("Disable HWP", value=False)
     if platform in ['satp1', 'satp2']:
         brake_default = True
@@ -98,36 +94,52 @@ with right_column:
         brake_default = False
         bore_rot = False
     brake_hwp = st.checkbox("Brake HWP", value=brake_default)
-    apply_boresight_rotation = st.checkbox("Apply Boresight Rotation", value=bore_rot)
+    if platform in ["satp1", "satp2"]:
+        apply_boresight_rotation = st.checkbox("Apply Boresight Rotation", value=bore_rot)
+    elif platform in ['satp3']:
+        apply_boresight_rotation = False
+
     az_branch_override = st.number_input("Az Branch Override (deg)", value=180.0)
     allow_partial_override = st.checkbox("Allow Partial Override", value=False)
     drift_override = st.checkbox("Drift Override", value=True)
     wiregrid_az = st.number_input("Wiregrid Azimuth (deg)", value=180.0)
-    wiregrid_el = st.number_input("Wiregrid Elevation (deg)", value=48.0)
+    wiregrid_el = st.number_input("Wiregrid Elevation (deg)", value=48.0, min_value=48.0)
+    az_offset = st.number_input("Azimuth Offset (deg)", value=0.0)
+    el_offset = st.number_input("Elevation Offset (deg)", value=0.0)
+    xi_offset = st.number_input("Xi Offset (deg)", value=0.0)
+    eta_offset = st.number_input("Eta Offset (deg)", value=0.0)
     # outfile = st.text_input("Output Filename")
     # cal_anchor_time = st.text_input("Calibration Anchor Time")
 
 
-
-# Track whether dropdown is shown
 if "show_dropdown" not in st.session_state:
     st.session_state.show_dropdown = False
 
-# Button to toggle the dropdown
-if st.button("Custom State" if not st.session_state.show_dropdown else "Default State"):
+# Toggle function
+def toggle_dropdown():
     st.session_state.show_dropdown = not st.session_state.show_dropdown
 
+# Button with on_click toggle
+st.button(
+    "Custom State" if not st.session_state.show_dropdown else "Default State",
+    on_click=toggle_dropdown
+)
+
+# Conditional content
 if st.session_state.show_dropdown:
     left_column_state, right_column_state = st.columns(2)
 
     with left_column_state:
         az_now = st.number_input("Azimuth Now", value=180.0, format="%.2f", key="az_now")
-        el_now = st.number_input("Elevation Now", value=48.0, format="%.2f", key="el_now")
+        el_now = st.number_input("Elevation Now", value=48.0, format="%.2f", key="el_now", min_value=40.0, max_value=90.0)
         az_speed_now = st.number_input("Azimuth Speed Now", value=0.0, format="%.2f", key="az_speed_now")
         az_accel_now = st.number_input("Azimuth Accel Now", value=0.0, format="%.2f", key="az_accel_now")
 
     with right_column_state:
-        boresight_rot_now = st.number_input("Boresight Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
+        if platform in ["satp1", "satp2"]:
+            boresight_rot_now = st.number_input("Boresight Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
+        elif platform in ["satp3"]:
+            boresight_rot_now = 0.0
         is_det_setup = st.checkbox("Det setup", value=False)
         has_active_channels = st.checkbox("Active Channels", value=True)
         hwp_spinning = st.checkbox("HWP Spinning", value=False)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -410,4 +410,4 @@ if st.button('Generate Schedule'):
     fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
     st.pyplot(fig)
 
-    st.code(schedule, language="text", line_numbers=True, height=500)
+    st.code(schedule, language="python", line_numbers=True, height=500)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -1,0 +1,217 @@
+import os
+import yaml
+
+import argparse
+import datetime as dt
+from schedlib import utils as u
+from schedlib.quality_assurance import SunCrawler
+
+import streamlit as st
+from matplotlib.backends.backend_agg import RendererAgg
+from threading import RLock
+
+logger = u.init_logger(__name__)
+
+_lock = RLock()
+
+schedule_base_dir = os.environ.get("SCHEDULE_BASE_DIR", 'master_schedules/')
+# dictionary goes dict[elevation][sun_keepout]
+schedule_files = {
+    50 : {
+        45: os.path.join(schedule_base_dir, '20250411_d-40,-10_e50_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365.txt'),
+        49: os.path.join(schedule_base_dir, '20250411_d-40,-10_e50_s0.5,0.8_a49_j2025-02-15T12:00+00:00_n365.txt'),
+    },
+    60 : {
+        45: os.path.join(schedule_base_dir, '20250411_d-40,-10_e60_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365.txt'),
+        49: os.path.join(schedule_base_dir, '20250411_d-40,-10_e60_s0.5,0.8_a49_j2025-02-15T12:00+00:00_n365.txt'),
+    }
+}
+
+cal_files = {
+    50 : {
+        45: os.path.join(schedule_base_dir, '20250411_d-40,-10_e50_s0.5,0.8_a45_j2025-02-15T12:00+00_:00_n365_planets.txt'),
+        49: os.path.join(schedule_base_dir, '20250411_d-40,-10_e50_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365_planets.txt'),
+    },
+    60 : {
+        45: os.path.join(schedule_base_dir, '20250411_d-40,-10_e60_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365_planets.txt'),
+        49: os.path.join(schedule_base_dir, '20250411_d-40,-10_e60_s0.5,0.8_a49_j2025-02-15T12:00+00:00_n365_planets.txt'),
+    }
+}
+
+wiregrid_files = {
+    50 : {
+        45: os.path.join(schedule_base_dir, '20250411_d-40,-10_e50_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365_wiregrid.txt'),
+        49: os.path.join(schedule_base_dir, '20250411_d-40,-10_e50_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365_wiregrid.txt'),
+    },
+    60 : {
+        45: os.path.join(schedule_base_dir, '20250411_d-40,-10_e60_s0.5,0.8_a45_j2025-02-15T12:00+00:00_n365_wiregrid.txt'),
+        49: os.path.join(schedule_base_dir, '20250411_d-40,-10_e60_s0.5,0.8_a49_j2025-02-15T12:00+00:00_n365_wiregrid.txt'),
+    }
+}
+
+left_column, right_column = st.columns(2)
+init_end_date = dt.date.today() + dt.timedelta(days=1)
+
+with left_column:
+    start_date = st.date_input("Start date", value=dt.date.today(), key='start_date')
+    end_date = st.date_input("End date", value=init_end_date, key='end_date')
+
+    platform = st.selectbox("Platform:", options=["satp1", "satp2", "satp3"])
+    elevation = st.selectbox("CMB Scan Elevation:", options=[50, 60], index=1)
+
+    use_cal_file = st.checkbox("Use Calibration File", value=False)
+    use_wiregrid_file = st.checkbox("Use Wiregrid File", value=False)
+
+    boresight = st.number_input("Boresight (deg)", value=0.0)
+    # cal_targets = st.text_input("Calibration Targets (comma-separated)")
+
+    no_cmb = st.checkbox("No CMB", value=False)
+    az_speed = st.number_input("Azimuth Speed (deg/s)", value=0.5)
+    az_accel = st.number_input("Azimuth Acceleration (deg/s²)", value=0.25)
+    az_offset = st.number_input("Azimuth Offset (deg)", value=0.0)
+    el_offset = st.number_input("Elevation Offset (deg)", value=0.0)
+    xi_offset = st.number_input("Xi Offset (deg)", value=0.0)
+    eta_offset = st.number_input("Eta Offset (deg)", value=0.0)
+    iv_cadence = st.number_input("IV Cadence (seconds)", value=14400)
+    bias_step_cadence = st.number_input("Bias Step Cadence (seconds)", value=1800)
+    min_hwp_el = st.number_input("Min HWP Elevation (deg)", value=48.0)
+    max_cmb_scan_duration = st.number_input("Max CMB Scan Duration (seconds)", value=3600)
+
+with right_column:
+    start_time = st.time_input("Start time (UTC)", value=dt.datetime.utcnow().time(), key='start_time')
+    end_time = st.time_input("End time (UTC)", value=dt.datetime.utcnow().time(), key='end_time')
+
+    hwp_override = st.checkbox("HWP Override", value=False)
+    az_motion_override = st.checkbox("Az Motion Override", value=False)
+    home_at_end = st.checkbox("Home at End", value=False)
+    relock_cadence = st.number_input("Relock Cadence (seconds)", value=86400)
+    disable_hwp = st.checkbox("Disable HWP", value=False)
+    if platform in ['satp1', 'satp2']:
+        brake_default = True
+        bore_rot = True
+    elif platform in ['satp3']:
+        brake_default = False
+        bore_rot = False
+    brake_hwp = st.checkbox("Brake HWP", value=brake_default)
+    apply_boresight_rotation = st.checkbox("Apply Boresight Rotation", value=bore_rot)
+    az_branch_override = st.number_input("Az Branch Override (deg)", value=180.0)
+    allow_partial_override = st.checkbox("Allow Partial Override", value=False)
+    drift_override = st.checkbox("Drift Override", value=True)
+    wiregrid_az = st.number_input("Wiregrid Azimuth (deg)", value=180.0)
+    wiregrid_el = st.number_input("Wiregrid Elevation (deg)", value=48.0)
+    # outfile = st.text_input("Output Filename")
+    # cal_anchor_time = st.text_input("Calibration Anchor Time")
+
+if st.button('Generate Schedule'):
+    t0 = dt.datetime.combine(
+        start_date, start_time, tzinfo=dt.timezone.utc
+    )
+    t1 = dt.datetime.combine(
+        end_date, end_time, tzinfo=dt.timezone.utc
+    )
+
+    cal_targets = []
+    t0_state_file = None
+    cal_anchor_time = None
+
+    match platform:
+        case "satp1":
+            from schedlib.policies.satp1 import SATP1Policy as Policy
+        case "satp2":
+            from schedlib.policies.satp2 import SATP2Policy as Policy
+        case "satp3":
+            from schedlib.policies.satp3 import SATP3Policy as Policy
+
+    if no_cmb:
+        sfile = os.path.join(schedule_base_dir, "empty_cmb.txt")
+    else:
+        sfile = schedule_files[int(elevation)]
+        if use_cal_file:
+            cfile = cal_files[int(elevation)]
+        else:
+            cfile = None
+        if use_wiregrid_file:
+            wgfile = wiregrid_files[int(elevation)]
+        else:
+            wgfile = None
+        if platform == 'satp1':
+            sfile = sfile[45] # absorptive baffle runs 45 degree keepout
+            if use_cal_file:
+                cfile = cfile[45]
+            if use_wiregrid_file:
+                wgfile = wgfile[45]
+        elif platform in ['satp2', 'satp3']:
+            sfile = sfile[49] # reflective baffle runs 49 degree keepout
+            if use_cal_file:
+                cfile = cfile[49]
+            if use_wiregrid_file:
+                wgfile = wgfile[49]
+        if not os.path.exists(sfile):
+            raise ValueError(f"Schedule file {sfile} does not exist")
+        if use_cal_file and not os.path.exists(cfile):
+            raise ValueError(f"Cal file {sfile} does not exist")
+
+    if (not t0_state_file is None) and (not os.path.exists(t0_state_file)):
+        print(f"Not using state file {t0_state_file} because it doesn't exist")
+        t0_state_file = None
+
+    if relock_cadence == "None":
+        relock_cadence = None
+    cfg = {
+        'az_speed': az_speed,
+        'az_accel': az_accel,
+        'az_offset': az_offset,
+        'el_offset': el_offset,
+        'xi_offset': xi_offset,
+        'eta_offset': eta_offset,
+        'iv_cadence': iv_cadence,
+        'bias_step_cadence': bias_step_cadence,
+        'min_hwp_el': min_hwp_el,
+        'max_cmb_scan_duration': max_cmb_scan_duration,
+        'disable_hwp': disable_hwp,
+        'brake_hwp': brake_hwp,
+        'apply_boresight_rot': apply_boresight_rotation,
+        'boresight_override': boresight,
+        'hwp_override': hwp_override,
+        'az_motion_override': az_motion_override,
+        'home_at_end': home_at_end,
+        'relock_cadence': relock_cadence,
+        'az_branch_override': az_branch_override,
+        'allow_partial_override': allow_partial_override,
+        'drift_override': drift_override,
+        'wiregrid_az': wiregrid_az,
+        'wiregrid_el': wiregrid_el,
+    }
+
+    policy = Policy.from_defaults(
+        master_file=sfile,
+        state_file = t0_state_file,
+        **cfg
+    )
+
+    policy.cal_targets = []
+    for target in cal_targets:
+        tb = target.get('boresight', None)
+        if tb is None:
+            target['boresight'] = boresight
+        policy.add_cal_target(**target)
+
+    seq = policy.init_cmb_seqs(t0, t1)
+    seq = policy.init_cal_seqs(cfile, wgfile, seq, t0, t1, cal_anchor_time)
+    seq = policy.apply(seq)
+    cmds, state = policy.seq2cmd(seq, t0, t1, return_state=True)
+    schedule = policy.cmd2txt(cmds, t0, t1)
+
+    sun_safe = False
+    try:
+        ## check sun safety
+        sc = SunCrawler(platform, cmd_txt=schedule, az_offset=az_offset, el_offset=el_offset)
+        sc.step_thru_schedule()
+    except Exception as e:
+        print("SCHEDULE NOT SUN SAFE")
+        sun_safe=False
+
+    if not sun_safe:
+        st.error("SunCrawer found the schedule is not Sun Safe")
+
+    st.code(schedule, language="text")

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -104,7 +104,7 @@ def build_table(t0, t1, cfg, seq, cmds, state, platform):
     plt.grid(True, axis='x', linestyle='--', alpha=0.5)
     plt.tight_layout()
 
-    return fig
+    return fig, df
 
 schedule_base_dir = os.environ.get("SCHEDULE_BASE_DIR", 'master_schedules/')
 # dictionary goes dict[elevation][sun_keepout]
@@ -421,7 +421,12 @@ if st.button('Generate Schedule'):
     if not sun_safe:
         st.error("SunCrawer found the schedule is not Sun Safe")
 
-    fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
-    st.pyplot(fig)
+    fig, df = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
+
+    with st.expander("Show Observation Plot"):
+        st.pyplot(fig)
+
+    with st.expander("Show Ref Table"):
+        st.dataframe(df)
 
     st.code(schedule, language="python", line_numbers=True, height=500)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
 import importlib
+from importlib.metadata import version
 
 import argparse
 import datetime as dt
@@ -141,6 +142,12 @@ wiregrid_files = {
 }
 
 st.title("SAT Scheduler")
+
+try:
+    schedlib_version = version("schedlib")
+    st.markdown(f"**schedlib version:** `{schedlib_version}`")
+except PackageNotFoundError:
+    st.error("schedlib is not installed or version metadata is missing.")
 
 st.subheader("Scheduler Parameters")
 left_column, right_column = st.columns(2)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -7,11 +7,15 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
+import importlib
+
 import argparse
 import datetime as dt
 from schedlib import utils as u
 from schedlib.quality_assurance import SunCrawler
-from schedlib.policies.sat import State
+import schedlib.policies.sat as sat
+importlib.reload(sat)
+State = sat.State
 
 import streamlit as st
 from matplotlib.backends.backend_agg import RendererAgg
@@ -283,11 +287,17 @@ if st.button('Generate Schedule'):
 
     match platform:
         case "satp1":
-            from schedlib.policies.satp1 import SATP1Policy as Policy
+            import schedlib.policies.satp1 as satp1
+            importlib.reload(satp1)
+            Policy = satp1.SATP1Policy
         case "satp2":
-            from schedlib.policies.satp2 import SATP2Policy as Policy
+            import schedlib.policies.satp2 as satp2
+            importlib.reload(satp2)
+            Policy = satp2.SATP2Policy
         case "satp3":
-            from schedlib.policies.satp3 import SATP3Policy as Policy
+            import schedlib.policies.satp3 as satp3
+            importlib.reload(satp3)
+            Policy = satp3.SATP3Policy
 
     if no_cmb:
         sfile = os.path.join(schedule_base_dir, "empty_cmb.txt")

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -153,6 +153,9 @@ if "start_time" not in st.session_state:
 if "end_time" not in st.session_state:
     st.session_state.end_time = dt.datetime.utcnow().time()
 
+if "boresight_override" not in st.session_state:
+    st.session_state.boresight_override = False
+
 with left_column:
     start_date = st.date_input("Start date", value=dt.date.today(), key='start_date')
     end_date = st.date_input("End date", value=init_end_date, key='end_date')
@@ -170,8 +173,6 @@ with left_column:
     az_accel = st.number_input("Azimuth Acceleration (deg/s²)", value=0.25)
     min_hwp_el = st.number_input("Min HWP Elevation (deg)", value=48.0)
     max_cmb_scan_duration = st.number_input("Max CMB Scan Duration (seconds)", value=3600)
-
-    boresight = st.number_input("Boresight (deg)", value=0.0)
     az_branch_override = st.number_input("Az Branch Override (deg) (Cal Sources)", value=180.0)
 
 with right_column:
@@ -180,6 +181,12 @@ with right_column:
     use_wiregrid_file = st.checkbox("Use Wiregrid File", value=False)
 
     hwp_override = st.radio("HWP Override", options=["None", "Forward (CCW)", "Reverse (CW)"], index=0)
+    st.checkbox("Boresight Override", value=st.session_state.boresight_override, key="boresight_override")
+
+    if st.session_state.boresight_override:
+        boresight = st.number_input("Boresight (deg)", value=0.0)
+    else:
+        boresight = None
 
     if hwp_override == "None":
         hwp_override = None

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -143,11 +143,17 @@ left_column, right_column = st.columns(2)
 
 init_end_date = dt.date.today() + dt.timedelta(days=1)
 
+if "start_time" not in st.session_state:
+    st.session_state.start_time = dt.datetime.utcnow().time()
+
+if "end_time" not in st.session_state:
+    st.session_state.end_time = dt.datetime.utcnow().time()
+
 with left_column:
     start_date = st.date_input("Start date", value=dt.date.today(), key='start_date')
     end_date = st.date_input("End date", value=init_end_date, key='end_date')
-    start_time = st.time_input("Start time (UTC)", value=dt.datetime.utcnow().time(), key='start_time')
-    end_time = st.time_input("End time (UTC)", value=dt.datetime.utcnow().time(), key='end_time')
+    start_time = st.time_input("Start time (UTC)", value=st.session_state.start_time, key='start_time')
+    end_time = st.time_input("End time (UTC)", value=st.session_state.end_time, key='end_time')
 
     platform = st.selectbox("Platform:", options=["satp1", "satp2", "satp3"])
     elevation = st.selectbox("CMB Scan Elevation:", options=[50, 60], index=1)
@@ -367,4 +373,4 @@ if st.button('Generate Schedule'):
     fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
     st.pyplot(fig)
 
-    st.code(schedule, language="text")
+    st.code(schedule, language="text", line_numbers=True)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -7,6 +7,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
+import plotly.graph_objects as go
+import plotly.express as px
+
 import importlib
 from importlib.metadata import version
 
@@ -70,41 +73,86 @@ def build_table(t0, t1, cfg, seq, cmds, state, platform):
 
         df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
 
-    names = sorted(df['name'].unique())
-    cmap = plt.get_cmap('tab10', len(names))
-    name_colors = {name: cmap(i) for i, name in enumerate(names)}
+    colors = {
+        "sat.cmb_scan": "#009E73",
+        "sat.source_scan": "#0072B2",
+        "sat.det_setup": "#D55E00",
+        "sat.ufm_relock": "#CC79A7",
+        "sat.bias_step": "#F0E442",
+        "sat.hwp_spin_up": "#56B4E9",
+        "sat.hwp_spin_down": "#E69F00",
+        "sat.setup_boresight": "#999999",
+        "sat.wiregrid": "#CCBB44",
+        "other": "#FFFFFF",
+    }
 
-    fig, ax = plt.subplots(figsize=(12, 6))
+    times = pd.date_range(t0, t1, freq='1s')
+    z = np.full((1, len(times)), -1, dtype=int)
+    hover_text = np.full((1, len(times)), '', dtype=object)
+
+    names = list(np.unique(df['name']))
+    name_to_idx = {name: i for i, name in enumerate(names)}
+
+    colorscale = []
+    n = len(names)
+    for i, name in enumerate(names):
+        c = colors[name]
+        colorscale.append([i / n, c])
+        colorscale.append([(i + 1) / n, c])
 
     for _, row in df.iterrows():
-        ax.barh(
-            y=0,
-            width=row['Stop Time UTC'] - row['#   Start Time UTC'],
-            left=row['#   Start Time UTC'],
-            height=0.4,
-            color=name_colors[row['name']],
-            edgecolor=name_colors[row['name']],
-            label=row['name']
+        start_idx = np.searchsorted(times, row['#   Start Time UTC'], side='left')
+        stop_idx = np.searchsorted(times, row['Stop Time UTC'], side='right')
+        name = row['name'] if row['name'] in name_to_idx else 'other'
+        idx = name_to_idx[name]
+        z[0, start_idx:stop_idx] = idx
+        for i in range(start_idx, stop_idx):
+            hover_text[0, i] = f"{name}<br>{times[i].strftime('%Y-%m-%d %H:%M:%S')}"
+
+    z = np.where(z == -1, np.nan, z)
+
+    ys = ["Operations"]
+
+    title_text = (
+        f"CMB: {np.round(100*total_cmb_time/total_duration,0)}% | "
+        f"Cal: {np.round(100*total_source_time/total_duration,0)}% | "
+        f"Setup: {np.round(100*total_setup_time/total_duration,0)}% | "
+        f"Other: {np.round(100 - 100*(total_cmb_time + total_setup_time + total_source_time)/total_duration,0)}%"
+    )
+
+    heatmap = go.Figure(
+        data=go.Heatmap(
+            z=z,
+            x=times,
+            y=ys,
+            text=hover_text,
+            hoverinfo="text",
+            colorscale=colorscale,
+            colorbar=dict(
+                tickvals=list(range(len(names))),
+                ticktext=names,
+            ),
+            zmin=0,
+            zmax=len(names) - 1,
+            ygap=1,
         )
+    )
 
-    ax.axvline(t0, color='black', linestyle='-', linewidth=1.5)
-    ax.axvline(t1, color='black', linestyle='-', linewidth=1.5)
+    heatmap.update_layout(
+        margin=dict(l=40, r=40, t=40, b=40),
+        height=400,
+        xaxis=dict(
+            title="Time",
+            tickformat="%H:%M",
+            tickangle=45,
+            range=[t0, t1]
+        ),
+        yaxis=dict(showticklabels=True),
+        title=title_text
+    )
 
-    handles, labels = ax.get_legend_handles_labels()
-    unique = dict(zip(labels, handles))
-    ax.legend(unique.values(), unique.keys(), title='Name', loc='upper right')
+    return heatmap, df
 
-    ax.set_yticks([])
-    ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H:%M'))
-    ax.xaxis.set_major_locator(mdates.HourLocator(interval=2))
-    plt.xticks(rotation=45)
-    plt.title(f"CMB: {np.round(100*total_cmb_time/total_duration,0)}% | Cal: {np.round(100*total_source_time/total_duration,0)}% | WG: "
-                f"{np.round(100*total_wiregrid_time/total_duration,0)}% | Setup: {np.round(100*total_setup_time/total_duration,0)}% | Other: "
-                f"{np.round(100 - 100*(total_setup_time + total_cmb_time + total_source_time + total_wiregrid_time)/total_duration,0)}%")
-    plt.grid(True, axis='x', linestyle='--', alpha=0.5)
-    plt.tight_layout()
-
-    return fig, df
 
 schedule_base_dir = os.environ.get("SCHEDULE_BASE_DIR", 'master_schedules/')
 # dictionary goes dict[elevation][sun_keepout]
@@ -424,7 +472,7 @@ if st.button('Generate Schedule'):
     fig, df = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
 
     with st.expander("Show Observation Plot"):
-        st.pyplot(fig)
+        st.plotly_chart(fig, use_container_width=True)
 
     with st.expander("Show Ref Table"):
         st.dataframe(df)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -111,21 +111,17 @@ with right_column:
     # outfile = st.text_input("Output Filename")
     # cal_anchor_time = st.text_input("Calibration Anchor Time")
 
-
 if "show_dropdown" not in st.session_state:
     st.session_state.show_dropdown = False
 
-# Toggle function
 def toggle_dropdown():
     st.session_state.show_dropdown = not st.session_state.show_dropdown
 
-# Button with on_click toggle
 st.button(
     "Custom State" if not st.session_state.show_dropdown else "Default State",
     on_click=toggle_dropdown
 )
 
-# Conditional content
 if st.session_state.show_dropdown:
     left_column_state, right_column_state = st.columns(2)
 
@@ -149,7 +145,6 @@ if st.session_state.show_dropdown:
         hwp_dir_val = None
     else:
         hwp_dir_val = hwp_dir.lower() == "forward"
-
 
 if st.button('Generate Schedule'):
     t0 = dt.datetime.combine(

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -175,7 +175,13 @@ with right_column:
     use_cal_file = st.checkbox("Use Calibration File", value=False)
     use_wiregrid_file = st.checkbox("Use Wiregrid File", value=False)
 
-    hwp_override = st.checkbox("HWP Override", value=False)
+    hwp_override = st.radio("HWP Override", options=["None", "Forward (CCW)", "Reverse (CW)"], index=0)
+
+    if hwp_override == "None":
+        hwp_override = None
+    else:
+        hwp_override = hwp_override.lower() == "forward (ccw)"
+
     az_motion_override = st.checkbox("Az Motion Override", value=False)
     home_at_end = st.checkbox("Home at End", value=False)
     disable_hwp = st.checkbox("Disable HWP", value=False)
@@ -256,12 +262,12 @@ with right_column_outer:
             is_det_setup = st.checkbox("Det setup", value=False)
             has_active_channels = st.checkbox("Active Channels", value=True)
             hwp_spinning = st.checkbox("HWP Spinning", value=False)
-            hwp_dir = st.radio("HWP Direction", options=["None", "Forward", "Reverse"], index=0)
+            hwp_dir = st.radio("HWP Direction", options=["None", "Forward (CCW)", "Reverse (CW)"], index=0)
 
         if hwp_dir == "None":
-            hwp_dir_val = None
+            hwp_dir = None
         else:
-            hwp_dir_val = hwp_dir.lower() == "forward"
+            hwp_dir = hwp_dir.lower() == "forward (ccw)"
 
 if st.button('Generate Schedule'):
     t0 = dt.datetime.combine(
@@ -394,4 +400,4 @@ if st.button('Generate Schedule'):
     fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
     st.pyplot(fig)
 
-    st.code(schedule, language="text", line_numbers=True)
+    st.code(schedule, language="text", line_numbers=True, height=500)

--- a/src/pages/6_SAT_Scheduler.py
+++ b/src/pages/6_SAT_Scheduler.py
@@ -206,41 +206,62 @@ with right_column:
     # outfile = st.text_input("Output Filename")
     # cal_anchor_time = st.text_input("Calibration Anchor Time")
 
+left_column_outer, right_column_outer = st.columns(2)
 
-if "show_dropdown" not in st.session_state:
-    st.session_state.show_dropdown = False
+with left_column_outer:
+    if "show_cal_target_dropdown" not in st.session_state:
+        st.session_state.show_cal_target_dropdown = False
+        cal_targets = []
 
-def toggle_dropdown():
-    st.session_state.show_dropdown = not st.session_state.show_dropdown
+    def toggle_dropdown():
+        st.session_state.show_cal_target_dropdown = not st.session_state.show_cal_target_dropdown
 
-st.button(
-    "Custom State" if not st.session_state.show_dropdown else "Default State",
-    on_click=toggle_dropdown
-)
+    st.button(
+        "Add Cal Targets" if not st.session_state.show_cal_target_dropdown else "Adding Cal Targets",
+        on_click=toggle_dropdown
+    )
 
-if st.session_state.show_dropdown:
-    left_column_state, right_column_state = st.columns(2)
-
-    with left_column_state:
-        az_now = st.number_input("Azimuth Now", value=180.0, format="%.2f", key="az_now")
-        el_now = st.number_input("Elevation Now", value=48.0, format="%.2f", key="el_now", min_value=40.0, max_value=90.0)
-        az_speed_now = st.number_input("Azimuth Speed Now", value=0.0, format="%.2f", key="az_speed_now")
-        az_accel_now = st.number_input("Azimuth Accel Now", value=0.0, format="%.2f", key="az_accel_now")
-
-    with right_column_state:
-        if platform in ["satp1", "satp2"]:
-            boresight_rot_now = st.number_input("Boresight Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
-        elif platform in ["satp3"]:
-            boresight_rot_now = 0.0
-        is_det_setup = st.checkbox("Det setup", value=False)
-        has_active_channels = st.checkbox("Active Channels", value=True)
-        hwp_spinning = st.checkbox("HWP Spinning", value=False)
-        hwp_dir = st.radio("HWP Direction", options=["None", "Forward", "Reverse"], index=0)
-
-    if hwp_dir == "None":
-        hwp_dir_val = None
+    if st.session_state.show_cal_target_dropdown:
+        yaml_input = st.text_area("Cal Targets", value="", height=200)
+        cal_targets = yaml.safe_load(yaml_input)
     else:
-        hwp_dir_val = hwp_dir.lower() == "forward"
+        cal_targets = []
+
+with right_column_outer:
+    if "show_state_dropdown" not in st.session_state:
+        st.session_state.show_state_dropdown = False
+
+    def toggle_dropdown():
+        st.session_state.show_state_dropdown = not st.session_state.show_state_dropdown
+
+    st.button(
+        "Custom State" if not st.session_state.show_state_dropdown else "Default State",
+        on_click=toggle_dropdown
+    )
+
+    if st.session_state.show_state_dropdown:
+        left_column_state, right_column_state = st.columns(2)
+
+        with left_column_state:
+            az_now = st.number_input("Azimuth Now", value=180.0, format="%.2f", key="az_now")
+            el_now = st.number_input("Elevation Now", value=48.0, format="%.2f", key="el_now", min_value=40.0, max_value=90.0)
+            az_speed_now = st.number_input("Azimuth Speed Now", value=0.0, format="%.2f", key="az_speed_now")
+            az_accel_now = st.number_input("Azimuth Accel Now", value=0.0, format="%.2f", key="az_accel_now")
+
+        with right_column_state:
+            if platform in ["satp1", "satp2"]:
+                boresight_rot_now = st.number_input("Boresight Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
+            elif platform in ["satp3"]:
+                boresight_rot_now = 0.0
+            is_det_setup = st.checkbox("Det setup", value=False)
+            has_active_channels = st.checkbox("Active Channels", value=True)
+            hwp_spinning = st.checkbox("HWP Spinning", value=False)
+            hwp_dir = st.radio("HWP Direction", options=["None", "Forward", "Reverse"], index=0)
+
+        if hwp_dir == "None":
+            hwp_dir_val = None
+        else:
+            hwp_dir_val = hwp_dir.lower() == "forward"
 
 if st.button('Generate Schedule'):
     t0 = dt.datetime.combine(
@@ -250,7 +271,7 @@ if st.button('Generate Schedule'):
         end_date, end_time, tzinfo=dt.timezone.utc
     )
 
-    cal_targets = []
+    #cal_targets = []
     t0_state_file = None
     cal_anchor_time = None
 
@@ -336,7 +357,7 @@ if st.button('Generate Schedule'):
             target['boresight'] = boresight
         policy.add_cal_target(**target)
 
-    if not st.session_state.show_dropdown:
+    if not st.session_state.show_state_dropdown:
         init_state = policy.init_state(t0)
     else:
         init_state = State(

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -99,7 +99,8 @@ def build_table(t0, t1, cfg, seq, cmds, state, platform):
                 f"Setup: {np.round(100*total_setup_time/total_duration,0)}% | Other: {np.round(100 - 100*(total_cmb_time + total_setup_time + total_source_time)/total_duration,0)}%")
     plt.grid(True, axis='x', linestyle='--', alpha=0.5)
     plt.tight_layout()
-    return fig
+
+    return fig, df
 
 schedule_base_dir = os.environ.get("LAT_SCHEDULE_BASE_DIR", 'master_schedules/')
 
@@ -352,7 +353,12 @@ if st.button('Generate Schedule'):
     if not sun_safe:
         st.error("SunCrawer found the schedule is not Sun Safe")
 
-    fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
-    st.pyplot(fig)
+    fig, df = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
+
+    with st.expander("Show Observation Plot"):
+        st.pyplot(fig)
+
+    with st.expander("Show Ref Table"):
+        st.dataframe(df)
 
     st.code(schedule, language="python", line_numbers=True, height=500)

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -156,30 +156,52 @@ with right_column:
     # outfile = st.text_input("Output Filename")
     # cal_anchor_time = st.text_input("Calibration Anchor Time")
 
-if "show_dropdown" not in st.session_state:
-    st.session_state.show_dropdown = False
+left_column_outer, right_column_outer = st.columns(2)
 
-def toggle_dropdown():
-    st.session_state.show_dropdown = not st.session_state.show_dropdown
+with left_column_outer:
+    if "show_cal_target_dropdown" not in st.session_state:
+        st.session_state.show_cal_target_dropdown = False
+        cal_targets = []
 
-st.button(
-    "Custom State" if not st.session_state.show_dropdown else "Default State",
-    on_click=toggle_dropdown
-)
+    def toggle_dropdown():
+        st.session_state.show_cal_target_dropdown = not st.session_state.show_cal_target_dropdown
 
-if st.session_state.show_dropdown:
-    left_column_state, right_column_state = st.columns(2)
+    st.button(
+        "Add Cal Targets" if not st.session_state.show_cal_target_dropdown else "Adding Cal Targets",
+        on_click=toggle_dropdown
+    )
 
-    with left_column_state:
-        az_now = st.number_input("Azimuth Now", value=180.0, format="%.2f", key="az_now")
-        el_now = st.number_input("Elevation Now", value=60.0, format="%.2f", key="el_now", min_value=40.0, max_value=90.0)
-        az_speed_now = st.number_input("Azimuth Speed Now", value=0.0, format="%.2f", key="az_speed_now")
-        az_accel_now = st.number_input("Azimuth Accel Now", value=0.0, format="%.2f", key="az_accel_now")
+    if st.session_state.show_cal_target_dropdown:
+        yaml_input = st.text_area("Cal Targets", value="", height=200)
+        cal_targets = yaml.safe_load(yaml_input)
+    else:
+        cal_targets = []
 
-    with right_column_state:
-        corotator_now = st.number_input("Corotator Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
-        is_det_setup = st.checkbox("Det setup", value=False)
-        has_active_channels = st.checkbox("Active Channels", value=True)
+with right_column_outer:
+    if "show_state_dropdown" not in st.session_state:
+        st.session_state.show_state_dropdown = False
+
+    def toggle_dropdown():
+        st.session_state.show_state_dropdown = not st.session_state.show_state_dropdown
+
+    st.button(
+        "Custom State" if not st.session_state.show_state_dropdown else "Default State",
+        on_click=toggle_dropdown
+    )
+
+    if st.session_state.show_state_dropdown:
+        left_column_state, right_column_state = st.columns(2)
+
+        with left_column_state:
+            az_now = st.number_input("Azimuth Now", value=180.0, format="%.2f", key="az_now")
+            el_now = st.number_input("Elevation Now", value=60.0, format="%.2f", key="el_now", min_value=40.0, max_value=90.0)
+            az_speed_now = st.number_input("Azimuth Speed Now", value=0.0, format="%.2f", key="az_speed_now")
+            az_accel_now = st.number_input("Azimuth Accel Now", value=0.0, format="%.2f", key="az_accel_now")
+
+        with right_column_state:
+            corotator_now = st.number_input("Corotator Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
+            is_det_setup = st.checkbox("Det setup", value=False)
+            has_active_channels = st.checkbox("Active Channels", value=True)
 
 if st.button('Generate Schedule'):
     t0 = dt.datetime.combine(
@@ -192,7 +214,7 @@ if st.button('Generate Schedule'):
     t0_state_file = None
     cal_anchor_time = None
     remove_targets = []
-    cal_targets = []
+    # cal_targets = []
 
     assert platform in ['lat'], (f"{platform} is not an "
             "implemented platform, you can only choose lat")
@@ -287,7 +309,7 @@ if st.button('Generate Schedule'):
             target['corotator'] = corotator
         policy.add_cal_target(**target)
 
-    if not st.session_state.show_dropdown:
+    if not st.session_state.show_state_dropdown:
         init_state = policy.init_state(t0)
     else:
         init_state = State(

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -104,13 +104,19 @@ left_column, right_column = st.columns(2)
 
 init_end_date = dt.date.today() + dt.timedelta(days=1)
 
+if "start_time" not in st.session_state:
+    st.session_state.start_time = dt.datetime.utcnow().time()
+
+if "end_time" not in st.session_state:
+    st.session_state.end_time = dt.datetime.utcnow().time()
+
 with left_column:
     platform = "lat"
 
     start_date = st.date_input("Start date", value=dt.date.today(), key='start_date')
     end_date = st.date_input("End date", value=init_end_date, key='end_date')
-    start_time = st.time_input("Start time (UTC)", value=dt.datetime.utcnow().time(), key='start_time')
-    end_time = st.time_input("End time (UTC)", value=dt.datetime.utcnow().time(), key='end_time')
+    start_time = st.time_input("Start time (UTC)", value=st.session_state.start_time, key='start_time')
+    end_time = st.time_input("End time (UTC)", value=st.session_state.end_time, key='end_time')
 
     az_speed = st.number_input("Azimuth Speed (deg/s)", value=0.5)
     az_accel = st.number_input("Azimuth Acceleration (deg/s²)", value=0.25)
@@ -315,4 +321,4 @@ if st.button('Generate Schedule'):
     fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
     st.pyplot(fig)
 
-    st.code(schedule, language="text")
+    st.code(schedule, language="text", line_numbers=True)

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
 import importlib
+from importlib.metadata import version
 
 import argparse
 import datetime as dt
@@ -103,6 +104,12 @@ def build_table(t0, t1, cfg, seq, cmds, state, platform):
 schedule_base_dir = os.environ.get("LAT_SCHEDULE_BASE_DIR", 'master_schedules/')
 
 st.title("LAT Scheduler")
+
+try:
+    schedlib_version = version("schedlib")
+    st.markdown(f"**schedlib version:** `{schedlib_version}`")
+except PackageNotFoundError:
+    st.error("schedlib is not installed or version metadata is missing.")
 
 st.subheader("Scheduler Parameters")
 left_column, right_column = st.columns(2)

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -343,4 +343,4 @@ if st.button('Generate Schedule'):
     fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
     st.pyplot(fig)
 
-    st.code(schedule, language="text", line_numbers=True)
+    st.code(schedule, language="text", line_numbers=True, height=500)

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -7,11 +7,16 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
+import importlib
+
 import argparse
 import datetime as dt
 from schedlib import utils as u, source as src
 from schedlib.quality_assurance import SunCrawler
-from schedlib.policies.lat import LATPolicy as Policy, State
+import schedlib.policies.lat as lat
+importlib.reload(lat)
+State = lat.State
+Policy = lat.LATPolicy
 from typing import Union
 
 import streamlit as st

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -348,4 +348,4 @@ if st.button('Generate Schedule'):
     fig = build_table(t0, t1, cfg, seq, cmds, init_state, platform)
     st.pyplot(fig)
 
-    st.code(schedule, language="text", line_numbers=True, height=500)
+    st.code(schedule, language="python", line_numbers=True, height=500)

--- a/src/pages/7_LAT_Scheduler.py
+++ b/src/pages/7_LAT_Scheduler.py
@@ -1,0 +1,221 @@
+import os
+import yaml
+
+import argparse
+import numpy as np
+import datetime as dt
+from schedlib import utils as u, source as src
+from schedlib.quality_assurance import SunCrawler
+from schedlib.policies.lat import LATPolicy as Policy, State
+from typing import Union
+
+import streamlit as st
+from matplotlib.backends.backend_agg import RendererAgg
+from threading import RLock
+
+logger = u.init_logger(__name__)
+
+_lock = RLock()
+
+schedule_base_dir = os.environ.get("LAT_SCHEDULE_BASE_DIR", 'master_schedules/')
+
+st.title("LAT Scheduler")
+
+st.subheader("Scheduler Parameters")
+left_column, right_column = st.columns(2)
+
+init_end_date = dt.date.today() + dt.timedelta(days=1)
+
+with left_column:
+    platform = "lat"
+
+    start_date = st.date_input("Start date", value=dt.date.today(), key='start_date')
+    end_date = st.date_input("End date", value=init_end_date, key='end_date')
+    use_cal_file = st.checkbox("Use Calibration File", value=False)
+    corotator = st.text_input("Corotator Angle [float, None, or Locked]", value="None")
+    try:
+        corotator = float(corotator)
+    except ValueError:
+        pass
+
+    # cal_targets = st.text_input("Calibration Targets (comma-separated)")
+
+    no_cmb = st.checkbox("No CMB", value=False)
+    az_speed = st.number_input("Azimuth Speed (deg/s)", value=0.5)
+    az_accel = st.number_input("Azimuth Acceleration (deg/s²)", value=0.25)
+    iv_cadence = st.number_input("IV Cadence (seconds)", value=14400)
+    relock_cadence = st.number_input("Relock Cadence (seconds)", value=86400)
+    bias_step_cadence = st.number_input("Bias Step Cadence (seconds)", value=1800)
+    max_cmb_scan_duration = st.number_input("Max CMB Scan Duration (seconds)", value=3600)
+    cryo_stabilization_time = st.number_input("Cryo Stabilization Time", value=180)
+
+with right_column:
+    start_time = st.time_input("Start time (UTC)", value=dt.datetime.utcnow().time(), key='start_time')
+    end_time = st.time_input("End time (UTC)", value=dt.datetime.utcnow().time(), key='end_time')
+
+    az_motion_override = st.checkbox("Az Motion Override", value=False)
+    apply_corotator_rotation = st.checkbox("Apply Corotator Rotation", value=False)
+    elevations_under_90 = st.checkbox("Elevations Under 90", value=True)
+    open_shutter = st.checkbox("Open Shutter", value=True)
+    close_shutter = st.checkbox("Close Shutter", value=True)
+
+    az_branch_override = st.number_input("Az Branch Override (deg)", value=180.0)
+    allow_partial_override = st.checkbox("Allow Partial Override", value=False)
+    drift_override = st.checkbox("Drift Override", value=True)
+    az_offset = st.number_input("Azimuth Offset (deg)", value=0.0)
+    el_offset = st.number_input("Elevation Offset (deg)", value=0.0)
+    xi_offset = st.number_input("Xi Offset (deg)", value=0.0)
+    eta_offset = st.number_input("Eta Offset (deg)", value=0.0)
+    corotator_offset = st.number_input("Corotator Offset (deg)", value=0.0)
+    # outfile = st.text_input("Output Filename")
+    # cal_anchor_time = st.text_input("Calibration Anchor Time")
+
+if "show_dropdown" not in st.session_state:
+    st.session_state.show_dropdown = False
+
+def toggle_dropdown():
+    st.session_state.show_dropdown = not st.session_state.show_dropdown
+
+st.button(
+    "Custom State" if not st.session_state.show_dropdown else "Default State",
+    on_click=toggle_dropdown
+)
+
+if st.session_state.show_dropdown:
+    left_column_state, right_column_state = st.columns(2)
+
+    with left_column_state:
+        az_now = st.number_input("Azimuth Now", value=180.0, format="%.2f", key="az_now")
+        el_now = st.number_input("Elevation Now", value=60.0, format="%.2f", key="el_now", min_value=40.0, max_value=90.0)
+        az_speed_now = st.number_input("Azimuth Speed Now", value=0.0, format="%.2f", key="az_speed_now")
+        az_accel_now = st.number_input("Azimuth Accel Now", value=0.0, format="%.2f", key="az_accel_now")
+
+    with right_column_state:
+        corotator_now = st.number_input("Corotator Rotation Now", value=0.0, format="%.2f", key="boresight_rot_now")
+        is_det_setup = st.checkbox("Det setup", value=False)
+        has_active_channels = st.checkbox("Active Channels", value=True)
+
+if st.button('Generate Schedule'):
+    t0 = dt.datetime.combine(
+        start_date, start_time, tzinfo=dt.timezone.utc
+    )
+    t1 = dt.datetime.combine(
+        end_date, end_time, tzinfo=dt.timezone.utc
+    )
+    schedule_file = None
+    t0_state_file = None
+    cal_anchor_time = None
+    remove_targets = []
+    cal_targets = []
+
+    assert platform in ['lat'], (f"{platform} is not an "
+            "implemented platform, you can only choose lat")
+
+    if relock_cadence == "None":
+            relock_cadence = None
+
+    if no_cmb:
+        sfile = os.path.join(
+            schedule_base_dir,
+            "empty_cmb.txt"
+        )
+    elif schedule_file is not None:
+        sfile = schedule_file
+    else:
+        sfile = os.path.join(
+            schedule_base_dir,
+            'iso/phase2/2025-05-23T20:46:10+00:00_phase2_cmb_lat_field_schedule.txt'
+        )
+
+    if use_cal_file:
+        cfile = os.path.join(
+            schedule_base_dir,
+            'iso/phase2/2025-05-22T17:29:30+00:00_calibration_lat_field_schedule.txt'
+        )
+    else:
+        cfile = None
+
+    if (not t0_state_file is None) and (not os.path.exists(t0_state_file)):
+        print(f"Not using state file {t0_state_file} because it doesn't exist")
+        t0_state_file = None
+
+
+    # scheduler runs with the corotator "locked to elevation axis" if
+    # corotator_override is None. But I am worried the None might get
+    # confusing so we'll enable the passing of "locked" as well
+
+    if type(corotator)==str:
+        if corotator.lower() == 'locked':
+            corotator = None
+        elif corotator.lower() == 'none':
+            corotator = None
+
+    cfg = {
+        'az_speed': az_speed,
+        'az_accel': az_accel,
+        'az_offset': az_offset,
+        'el_offset': el_offset,
+        'xi_offset': xi_offset,
+        'eta_offset': eta_offset,
+        'iv_cadence': iv_cadence,
+        'bias_step_cadence': bias_step_cadence,
+        'max_cmb_scan_duration': max_cmb_scan_duration,
+        'az_motion_override': az_motion_override,
+        'corotator_override': corotator,
+        'apply_corotator_rot': apply_corotator_rotation,
+        'cryo_stabilization_time': cryo_stabilization_time,
+        'corotator_offset': corotator_offset,
+        'elevations_under_90' : elevations_under_90,
+        'remove_targets': tuple(remove_targets),
+        'open_shutter': open_shutter,
+        'close_shutter': close_shutter,
+        'relock_cadence': relock_cadence,
+        'az_branch_override': az_branch_override,
+        'allow_partial_override': allow_partial_override,
+        'drift_override': drift_override,
+        'az_stow' : 180,
+        'el_stow' : 60,
+    }
+
+    policy = Policy.from_defaults(
+        master_file=sfile,
+        state_file = t0_state_file,
+        **cfg
+    )
+    policy.cal_targets = []
+    for target in cal_targets:
+        if target['source'] not in src.get_source_list():
+            assert 'ra' in target and 'dec' in target, "need RA and DEC"
+            src.add_fixed_source(
+                name=target['source'],
+                ra=target['ra'], dec=target['dec'],
+                ra_units='deg'
+            )
+        if 'ra' in target:
+            target.pop("ra")
+        if 'dec' in target:
+            target.pop("dec")
+        if 'elevation' not in target:
+            target['elevation'] = elevation
+        if 'corotator' not in target:
+            target['corotator'] = corotator
+        policy.add_cal_target(**target)
+
+    seq = policy.init_seqs(cfile, t0, t1)
+    seq = policy.apply(seq)
+    cmds, state = policy.seq2cmd(seq, t0, t1, return_state=True)
+    schedule = policy.cmd2txt(cmds, t0, t1)
+
+    sun_safe = True
+    try:
+        ## check sun safety
+        sc = SunCrawler(platform, cmd_txt=schedule, az_offset=az_offset, el_offset=el_offset)
+        sc.step_thru_schedule()
+    except Exception as e:
+        print("SCHEDULE NOT SUN SAFE")
+        sun_safe=False
+
+    if not sun_safe:
+        st.error("SunCrawer found the schedule is not Sun Safe")
+
+    st.code(schedule, language="text")


### PR DESCRIPTION
Adds a page that allows for configuring and running the `scheduler` for the SATs and the LAT.  Outputs a schedule to the browser and the plot from (https://github.com/simonsobs/scheduler-scripts/pull/44).  Can pass in `yaml` formatted text to optionally add manual cal targets.  State can be optionally configured.  Most options are supported though some things that aren't likely to be changed aren't configurable right now.

Probably will want to modularize `scheduler_scripts` somehow in the future to prevent duplication of `gen_schedule` code here.